### PR TITLE
feat: implement transaction sending endpoint with input validation and structured responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ This project supports:
 - [x] Project setup (Spring Boot + bitcoinj)
 - [x] Implement mnemonic generation and seed derivation (BIP-39)
 - [x] Address derivation (BIP-44)
-- [ ] Blockchain connection and sync (SPV)
-- [ ] Balance and transaction history endpoints
-- [ ] Transaction signing and broadcasting
+- [x] Blockchain connection and sync (SPV)
+- [x] Balance and transaction history endpoints
+- [ ] Transaction signing and broadcasting (testing phase)
 - [ ] Secure storage with AES encryption
 - [ ] JavaFX/CLI interface
 - [ ] Mainnet support

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,10 @@
             <version>33.4.8-jre</version>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>

--- a/src/main/java/com/mcd/wallet/controller/WalletController.java
+++ b/src/main/java/com/mcd/wallet/controller/WalletController.java
@@ -1,0 +1,34 @@
+package com.mcd.wallet.controller;
+
+import org.springframework.web.bind.annotation.*;
+import com.mcd.wallet.service.BlockchainService;
+import org.bitcoinj.wallet.Wallet;
+import org.springframework.beans.factory.annotation.Autowired;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/wallet")
+public class WalletController {
+
+    private final BlockchainService blockchainService;
+
+    @Autowired
+    public WalletController(BlockchainService blockchainService) {
+        this.blockchainService = blockchainService;
+    }
+
+    @GetMapping("/balance")
+    public String getBalance() {
+        Wallet wallet = blockchainService.getWalletAppKit().wallet();
+        return wallet.getBalance().toFriendlyString();
+    }
+
+    @GetMapping("/transactions")
+    public List<String> getTransactions() {
+        Wallet wallet = blockchainService.getWalletAppKit().wallet();
+        return wallet.getTransactions(false).stream()
+                .map(tx -> "TXID: " + tx.getTxId() + " | Valor: " + tx.getValue(wallet).toFriendlyString())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/mcd/wallet/controller/WalletController.java
+++ b/src/main/java/com/mcd/wallet/controller/WalletController.java
@@ -1,15 +1,33 @@
 package com.mcd.wallet.controller;
 
-import org.springframework.web.bind.annotation.*;
+import com.mcd.wallet.controller.dto.ErrorResponse;
+import com.mcd.wallet.controller.dto.SendBitcoinRequest;
+import com.mcd.wallet.controller.dto.TransactionResponse;
 import com.mcd.wallet.service.BlockchainService;
+import org.bitcoinj.core.Address;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.InsufficientMoneyException;
 import org.bitcoinj.wallet.Wallet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/wallet")
 public class WalletController {
+
+    private static final Logger logger = LoggerFactory.getLogger(WalletController.class);
 
     private final BlockchainService blockchainService;
 
@@ -31,4 +49,79 @@ public class WalletController {
                 .map(tx -> "TXID: " + tx.getTxId() + " | Valor: " + tx.getValue(wallet).toFriendlyString())
                 .collect(Collectors.toList());
     }
-}
+
+    @PostMapping("/send")
+    public ResponseEntity<?> sendTransaction(@Valid @RequestBody SendBitcoinRequest request) {
+        try {
+            // Input validation
+            if (request.address() == null || request.address().isEmpty()) {
+                return ResponseEntity.badRequest()
+                        .body(new ErrorResponse("ADDRESS_INVALID", "Bitcoin address cannot be empty"));
+            }
+
+            if (request.amount() == null || request.amount().isEmpty()) {
+                return ResponseEntity.badRequest()
+                        .body(new ErrorResponse("AMOUNT_INVALID", "Amount cannot be empty"));
+            }
+
+            Wallet wallet = blockchainService.getWalletAppKit().wallet();
+
+            // Parse and validate amount
+            Coin value;
+            try {
+                value = Coin.parseCoin(request.amount());
+                if (!value.isGreaterThan(Coin.ZERO)) {
+                    return ResponseEntity.badRequest()
+                            .body(new ErrorResponse("AMOUNT_INVALID", "Amount must be greater than zero"));
+                }
+            } catch (IllegalArgumentException e) {
+                return ResponseEntity.badRequest()
+                        .body(new ErrorResponse("AMOUNT_INVALID", "Invalid amount format"));
+            }
+
+            // Parse and validate address
+            Address toAddress;
+            try {
+                toAddress = Address.fromString(wallet.getNetworkParameters(), request.address());
+            } catch (IllegalArgumentException e) {
+                return ResponseEntity.badRequest()
+                        .body(new ErrorResponse("ADDRESS_INVALID", "Invalid bitcoin address"));
+            }
+
+            // Check balance
+            if (wallet.getBalance().isLessThan(value)) {
+                return ResponseEntity.badRequest()
+                        .body(new ErrorResponse("INSUFFICIENT_FUNDS", "Insufficient wallet balance"));
+            }
+
+            // Send with timeout
+            CompletableFuture<Wallet.SendResult> future = CompletableFuture.supplyAsync(() -> {
+                try {
+                    return wallet.sendCoins(blockchainService.getWalletAppKit().peerGroup(), toAddress, value);
+                } catch (InsufficientMoneyException e) {
+                    throw new CompletionException(e);
+                }
+            });
+
+            Wallet.SendResult result = future.get(30, TimeUnit.SECONDS);
+
+            return ResponseEntity.ok(new TransactionResponse(
+                    result.tx.getTxId().toString(),
+                    value.toFriendlyString()
+            ));
+
+        } catch (TimeoutException e) {
+            return ResponseEntity.status(HttpStatus.GATEWAY_TIMEOUT)
+                    .body(new ErrorResponse("TIMEOUT", "Transaction timed out"));
+        } catch (Exception e) {
+            logger.error("Error processing transaction", e);
+            if (e instanceof CompletionException ce && ce.getCause() instanceof InsufficientMoneyException) {
+                return ResponseEntity.badRequest()
+                        .body(new ErrorResponse("INSUFFICIENT_FUNDS", "Insufficient wallet balance"));
+            }
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ErrorResponse("INTERNAL_ERROR", "An internal error occurred"));
+        }
+
+    }
+    }

--- a/src/main/java/com/mcd/wallet/controller/dto/ErrorResponse.java
+++ b/src/main/java/com/mcd/wallet/controller/dto/ErrorResponse.java
@@ -1,0 +1,4 @@
+package com.mcd.wallet.controller.dto;
+
+public class ErrorResponse {
+}

--- a/src/main/java/com/mcd/wallet/controller/dto/ErrorResponse.java
+++ b/src/main/java/com/mcd/wallet/controller/dto/ErrorResponse.java
@@ -1,4 +1,11 @@
 package com.mcd.wallet.controller.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
 public class ErrorResponse {
+    private String code;
+    private String message;
 }

--- a/src/main/java/com/mcd/wallet/controller/dto/SendBitcoinRequest.java
+++ b/src/main/java/com/mcd/wallet/controller/dto/SendBitcoinRequest.java
@@ -1,4 +1,4 @@
 package com.mcd.wallet.controller.dto;
 
-public class SendBitcoinRequest {
+public record SendBitcoinRequest(String address, String amount) {
 }

--- a/src/main/java/com/mcd/wallet/controller/dto/SendBitcoinRequest.java
+++ b/src/main/java/com/mcd/wallet/controller/dto/SendBitcoinRequest.java
@@ -1,0 +1,4 @@
+package com.mcd.wallet.controller.dto;
+
+public class SendBitcoinRequest {
+}

--- a/src/main/java/com/mcd/wallet/controller/dto/TransactionResponse.java
+++ b/src/main/java/com/mcd/wallet/controller/dto/TransactionResponse.java
@@ -1,4 +1,4 @@
 package com.mcd.wallet.controller.dto;
 
-public class TransactionResponse {
+public record TransactionResponse(String txId, String amount) {
 }

--- a/src/main/java/com/mcd/wallet/controller/dto/TransactionResponse.java
+++ b/src/main/java/com/mcd/wallet/controller/dto/TransactionResponse.java
@@ -1,0 +1,4 @@
+package com.mcd.wallet.controller.dto;
+
+public class TransactionResponse {
+}


### PR DESCRIPTION
## Summary

This PR adds the initial implementation for sending Bitcoin transactions through the `/api/wallet/send` endpoint.

It includes:
- Input validation for address and amount.
- Transaction signing and broadcasting using WalletAppKit and PeerGroup.
- Structured success and error responses with dedicated DTOs (`TransactionResponse` and `ErrorResponse`).
- Timeout handling for transaction broadcasting (30 seconds).
- Internal error handling and logging improvements.

## Notes

Transaction signing and broadcasting have not yet been tested on the Bitcoin Testnet with real balance.  
Real integration testing is required to validate end-to-end functionality.

## Changes

- Added `WalletController` with `/send` endpoint.
- Created `SendBitcoinRequest`, `TransactionResponse`, and `ErrorResponse` DTOs.
- Updated input validation and exception handling structure.
- Minor adjustments to project dependencies.

## Checklist

- [x] Address input validation
- [x] Amount input validation
- [x] Successful transaction response
- [x] Structured error handling
- [ ] Test transaction sending on Bitcoin Testnet
